### PR TITLE
Fix closed file error in transcription

### DIFF
--- a/transcription_simple.py
+++ b/transcription_simple.py
@@ -158,8 +158,7 @@ class TranscriptionProcessor:
                 else:
                     raise Exception(f"Неподдерживаемый формат аудио: {audio_format}")
                     
-                # Закрываем BytesIO
-                audio_io.close()
+                # BytesIO будет автоматически закрыт при сборке мусора
                 
             except Exception as e:
                 raise Exception(f"Ошибка декодирования аудио: {e}")


### PR DESCRIPTION
## Summary
- remove premature BytesIO close in transcription module

## Testing
- `pytest -q` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860345265d883239292e364b8ab4c53