### PR TITLE
Fix dtype mismatch in simple transcription

### DIFF
--- a/transcription_simple.py
+++ b/transcription_simple.py
@@ -184,8 +184,15 @@ class TranscriptionProcessor:
             all_text = []
             for i, chunk in enumerate(tqdm(chunks, desc="Транскрибация")):
                 # Подготовка входных данных
-                inputs = self.processor(chunk, sampling_rate=16000, return_tensors="pt")
-                input_features = inputs.input_features.to(self.device)
+                inputs = self.processor(
+                    chunk,
+                    sampling_rate=16000,
+                    return_tensors="pt"
+                )
+                input_features = inputs.input_features.to(
+                    device=self.device,
+                    dtype=self.torch_dtype
+                )
                 
                 # Генерация
                 with torch.no_grad():


### PR DESCRIPTION
## Summary
- ensure transcription_simple casts input features to the model's dtype

## Testing
- `python test_transcription.py` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686039bfe3e88323882c654bc19ea374