### PR TITLE
Enable per-file transcript download

### DIFF
--- a/pwa_simple.py
+++ b/pwa_simple.py
@@ -359,6 +359,26 @@ def api_download_transcription():
     response.headers['Content-Disposition'] = 'attachment; filename=transcription_results.txt'
     return response
 
+@app.route('/api/download-transcription/<int:index>')
+def api_download_transcription_file(index):
+    """Скачивание отдельного результата транскрибации"""
+    global transcription_status
+
+    results = transcription_status.get('results', [])
+    if index < 0 or index >= len(results):
+        return jsonify({'error': 'Неверный индекс'}), 400
+
+    result = results[index]
+    if not result.get('success'):
+        return jsonify({'error': 'Результат недоступен'}), 400
+
+    from flask import make_response
+    text_filename = f"{Path(result['filename']).stem}.txt"
+    response = make_response(result['text'])
+    response.headers['Content-Type'] = 'text/plain; charset=utf-8'
+    response.headers['Content-Disposition'] = f'attachment; filename={text_filename}'
+    return response
+
 @app.route('/api/system-info')
 def api_system_info():
     """Информация о системе"""

--- a/static/app.js
+++ b/static/app.js
@@ -386,21 +386,29 @@ class AudioTranslatorApp {
 
     displayTranscriptionResults(results) {
         const resultsDiv = document.getElementById('transcriptionResults');
-        
+
         resultsDiv.innerHTML = `
             <h3>Результаты транскрибации</h3>
             <div class="results-list">
-                ${results.map(result => `
+                ${results.map((result, index) => `
                     <div class="result-item ${result.success ? 'success' : 'error'}">
                         <h4>${result.filename}</h4>
-                        ${result.success ? 
-                            `<div class="transcription-text">${result.text}</div>` : 
+                        ${result.success ?
+                            `<div class="transcription-text">${result.text}</div>
+                             <button class="btn btn-outline download-txt" data-index="${index}">💾 Скачать TXT</button>` :
                             `<div class="error-text">Ошибка: ${result.error}</div>`
                         }
                     </div>
                 `).join('')}
             </div>
         `;
+
+        resultsDiv.querySelectorAll('.download-txt').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const idx = btn.dataset.index;
+                window.open('/api/download-transcription/' + idx, '_blank');
+            });
+        });
     }
 
     async handleTextFileSelect(event) {


### PR DESCRIPTION
## Summary
- add API endpoint for individual transcription download
- add download button per transcription result in UI

## Testing
- `pytest -q` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68603b6bf5a48323a32b0da676946903