### PR TITLE
Handle transcription start errors

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -338,9 +338,11 @@ class AudioTranslatorApp {
             });
 
             const result = await response.json();
-            
+
             if (!result.success) {
                 this.showAlert(result.error, 'error');
+                progressBar.style.display = 'none';
+                progressText.textContent = '';
                 return;
             }
 
@@ -384,6 +386,8 @@ class AudioTranslatorApp {
             } else {
                 this.showAlert('Ошибка запуска транскрибации: ' + error.message, 'error');
             }
+            progressBar.style.display = 'none';
+            progressText.textContent = '';
         } finally {
             this.isTranscribing = false;
             transcribeBtn.disabled = false;


### PR DESCRIPTION
## Summary
- hide the progress bar if the transcription request fails

## Testing
- `pytest -q` *(fails: PyTorch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686041bc67548323bb41b6be50c8491c