### PR TITLE
Add web progress updates for transcription

### DIFF
--- a/pwa_simple.py
+++ b/pwa_simple.py
@@ -102,16 +102,23 @@ def api_transcribe():
             global transcription_status
             transcription_status["status"] = "processing"
             transcription_status["results"] = []
+            transcription_status["progress"] = 0
 
             try:
                 processor = TranscriptionProcessor()
+
+                total_files = len(file_list)
 
                 for i, item in enumerate(file_list):
                     temp_path = item["path"]
                     original_name = item["original"]
 
+                    def chunk_progress(pct, file_index=i):
+                        overall = ((file_index + pct / 100) / total_files) * 100
+                        transcription_status["progress"] = overall
+
                     # Транскрибация
-                    result = processor.transcribe_file(temp_path)
+                    result = processor.transcribe_file(temp_path, progress_callback=chunk_progress)
 
                     # Создание текстового файла с результатом
                     text_filename = (
@@ -134,8 +141,8 @@ def api_transcribe():
                     except Exception:
                         pass
 
-                    transcription_status["progress"] = ((i + 1) / len(file_list)) * 100
 
+                transcription_status["progress"] = 100
                 transcription_status["status"] = "completed"
             except Exception as e:
                 transcription_status["status"] = "error"

--- a/transcription_simple.py
+++ b/transcription_simple.py
@@ -110,7 +110,7 @@ class TranscriptionProcessor:
         except Exception as e:
             raise Exception(f"Критическая ошибка загрузки модели: {e}")
     
-    def transcribe_file(self, file_path):
+    def transcribe_file(self, file_path, progress_callback=None):
         """
         Транскрибация одного аудиофайла
         
@@ -182,6 +182,7 @@ class TranscriptionProcessor:
             
             # Транскрибация чанков
             all_text = []
+            total_chunks = len(chunks)
             for i, chunk in enumerate(tqdm(chunks, desc="Транскрибация")):
                 # Подготовка входных данных
                 inputs = self.processor(
@@ -211,6 +212,13 @@ class TranscriptionProcessor:
                 )[0]
                 
                 all_text.append(transcription.strip())
+
+                if progress_callback:
+                    progress = ((i + 1) / total_chunks) * 100
+                    try:
+                        progress_callback(progress)
+                    except Exception:
+                        pass
             
             # Объединение результатов
             final_text = " ".join(all_text)


### PR DESCRIPTION
## Summary
- add progress_callback in `transcription_simple.py`
- update `pwa_simple.py` to expose chunk-based progress through `/api/transcription-status`

## Testing
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6860e92dfb088323979fbb6b8177a2a1