### PR TITLE
Add API delay and improve settings persistence

### DIFF
--- a/pwa_app.py
+++ b/pwa_app.py
@@ -221,20 +221,21 @@ def api_translate():
 
                     try:
                         translation = translator.translate_text(chunk)
-                        translation_status["translations"][i] = translation
+                        translation_status["translations"][str(i)] = translation
                     except Exception as e:
-                        translation_status["translations"][
-                            i
-                        ] = f"[Ошибка перевода: {str(e)}]"
+                        translation_status["translations"][str(i)] = (
+                            f"[Ошибка перевода: {str(e)}]"
+                        )
 
-                    time.sleep(0.1)  # Небольшая пауза между запросами
+                    # Задержка между запросами для избежания лимитов
+                    time.sleep(5)
 
             else:
                 # Переводим один чанк
                 if chunk_index is not None and 0 <= chunk_index < len(chunks):
                     chunk = chunks[chunk_index]
                     translation = translator.translate_text(chunk)
-                    translation_status["translations"][chunk_index] = translation
+                    translation_status["translations"][str(chunk_index)] = translation
                     translation_status["progress"] = 100
 
             translation_status["progress"] = 100

--- a/pwa_simple.py
+++ b/pwa_simple.py
@@ -261,11 +261,12 @@ def api_translate():
                         translation = translator.translate_text(chunk)
                         translation_status["translations"][str(i)] = translation
                     except Exception as e:
-                        translation_status["translations"][
-                            str(i)
-                        ] = f"[Ошибка перевода: {str(e)}]"
+                        translation_status["translations"][str(i)] = (
+                            f"[Ошибка перевода: {str(e)}]"
+                        )
 
-                    time.sleep(0.1)  # Небольшая пауза между запросами
+                    # Задержка между запросами для избежания лимитов
+                    time.sleep(5)
 
             else:
                 # Переводим один чанк

--- a/static/app.js
+++ b/static/app.js
@@ -663,6 +663,11 @@ class AudioTranslatorApp {
         .then(response => response.json())
         .then(result => {
             if (result.success) {
+                // Сохраняем настройки локально
+                localStorage.setItem('api_endpoint', settings.api_endpoint);
+                localStorage.setItem('api_token', settings.api_token);
+                localStorage.setItem('api_model', settings.api_model);
+                localStorage.setItem('system_prompt', settings.system_prompt);
                 this.showAlert('Настройки сохранены', 'success');
                 this.hideSettingsModal();
             } else {
@@ -679,7 +684,11 @@ class AudioTranslatorApp {
             .then(response => response.json())
             .then(result => {
                 if (result.success) {
-                    // Настройки загружены
+                    const s = result.settings;
+                    localStorage.setItem('api_endpoint', s.api_endpoint || '');
+                    localStorage.setItem('api_token', s.api_token || '');
+                    localStorage.setItem('api_model', s.api_model || 'gpt-3.5-turbo');
+                    localStorage.setItem('system_prompt', s.system_prompt || '');
                 }
             })
             .catch(error => {


### PR DESCRIPTION
## Summary
- add 5 second delay between translation API calls
- store translations with string keys
- persist API settings in localStorage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f56abda88323aefffbd792e74b70