### PR TITLE
Improve error output for translation API

### DIFF
--- a/translation.py
+++ b/translation.py
@@ -53,7 +53,17 @@ class TranslationProcessor:
                     time.sleep(wait_time)
                     continue
                 else:
-                    response.raise_for_status()
+                    error_message = f"HTTP {response.status_code}"
+                    try:
+                        data = response.json()
+                        if isinstance(data, dict):
+                            msg = data.get("error") or data.get("message")
+                            if msg:
+                                error_message += f" - {msg}"
+                    except Exception:
+                        if response.text:
+                            error_message += f" - {response.text}"
+                    raise Exception(f"Ошибка API: {error_message}")
                     
             except requests.exceptions.Timeout:
                 if attempt < retry_count - 1:


### PR DESCRIPTION
## Summary
- capture HTTP error details when translation API responds with non-200 status

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860f8644c148323a9144eaffe065270